### PR TITLE
Add the option to put the compressed files in a dedicated directory

### DIFF
--- a/src/zopfli-plugin.js
+++ b/src/zopfli-plugin.js
@@ -29,35 +29,25 @@ class WebpackPlugin {
   }
 }
 
-async function compressFile (file, pluginOptions) {
+async function compressFile (file, pluginOptions = {}) {
   // zopfli-gzip the asset to a new file with the .gz extension
   const readFileAsync = util.promisify(fs.readFile)
   const writeFileAsync = util.promisify(fs.writeFile)
 
-  const filePath = path.join(process.cwd(), 'public', file)
-  const content = await readFileAsync(filePath)
+  const fileBasePath = path.join(process.cwd(), 'public')
+  const srcFileName = path.join(fileBasePath, file)
+  const content = await readFileAsync(srcFileName)
   const compressed = await zopfli.gzipAsync(content, {})
-  let newFileName = filePath + '.gz'
 
-  if (pluginOptions && pluginOptions.path) {
-    let path = pluginOptions.path
-    if (!path.startsWith('/')) {
-      path = '/' + path
-    }
-    if (!path.endsWith('/')) {
-      path = path + '/'
-    }
-    newFileName = newFileName.replace('/public/', `/public${path}`)
+  const destFilePath = (pluginOptions.path) ? path.join(fileBasePath, pluginOptions.path) : fileBasePath
+  const destFileName = path.join(destFilePath, file) + '.gz'
 
+  if (!fs.existsSync(destFilePath)) {
     const mkdirAsync = util.promisify(fs.mkdir)
-    const dir = newFileName.split(path)[0] + path
-
-    if (!fs.existsSync(dir)) {
-      await mkdirAsync(dir)
-    }
+    await mkdirAsync(destFilePath)
   }
 
-  await writeFileAsync(newFileName, compressed)
+  await writeFileAsync(destFileName, compressed)
 }
 
 function onPostBuild (args, pluginOptions) {

--- a/src/zopfli-plugin.js
+++ b/src/zopfli-plugin.js
@@ -29,7 +29,7 @@ class WebpackPlugin {
   }
 }
 
-async function compressFile (file) {
+async function compressFile (file, pluginOptions) {
   // zopfli-gzip the asset to a new file with the .gz extension
   const readFileAsync = util.promisify(fs.readFile)
   const writeFileAsync = util.promisify(fs.writeFile)
@@ -37,14 +37,33 @@ async function compressFile (file) {
   const filePath = path.join(process.cwd(), 'public', file)
   const content = await readFileAsync(filePath)
   const compressed = await zopfli.gzipAsync(content, {})
-  const newFileName = filePath + '.gz'
+  let newFileName = filePath + '.gz'
+
+  if (pluginOptions && pluginOptions.path) {
+    let path = pluginOptions.path
+    if (!path.startsWith('/')) {
+      path = '/' + path
+    }
+    if (!path.endsWith('/')) {
+      path = path + '/'
+    }
+    newFileName = newFileName.replace('/public/', `/public${path}`)
+
+    const mkdirAsync = util.promisify(fs.mkdir)
+    const dir = newFileName.split(path)[0] + path
+
+    if (!fs.existsSync(dir)) {
+      await mkdirAsync(dir)
+    }
+  }
+
   await writeFileAsync(newFileName, compressed)
 }
 
 function onPostBuild (args, pluginOptions) {
   // after asset files have been generated, compress them
   const compress = Object.keys(assetsCompress).map(file => {
-    return compressFile(file)
+    return compressFile(file, pluginOptions)
   })
   return Promise.all(compress)
 }


### PR DESCRIPTION
As I wrote in the [`gatsby-plugin-brotli` PR](https://github.com/ovhemert/gatsby-plugin-brotli/pull/6): the devops I work with asked me to put the brotli-compressed files in a dedicated directory.
Our need was to serve the static files with CloudFront, using S3 as the origin (in a transparently way from a front-end perspective). The only way to do that is with a specific path.

Since we added the brotli-compressed version of the files we had to disable the automatic compression (gzip) and so I had to do the same thing for the gzip-compressed files. That's why I've opened this PR too.