### PR TITLE
This commit adds a couple of minor enhancements to the library:

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ module.exports = {
 }
 ```
 
+To customize compression, you can add optional parameters to the zopfli library: ([see here for details on various options)](https://github.com/pierreinglebert/node-zopfli#options)
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-zopfli',
+      zopfli: {
+        verbose: false,
+        verbose_more: false,
+        numiterations: 15,
+        blocksplitting: true,
+        blocksplittinglast: false,
+        blocksplittingmax: 15
+      }
+    }
+  ]
+}
+```
+
+For diagnostic information, you can enable verbose logging:
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-zopfli',
+      verbose: true
+    }
+  ]
+}
+```
+
 ## Maintainers
 
 Osmond van Hemert

--- a/src/zopfli-plugin.js
+++ b/src/zopfli-plugin.js
@@ -13,26 +13,54 @@ const defaultOptions = {
 
 const globAsync = util.promisify(glob)
 
-async function onPostBuild (args, pluginOptions) {
+async function onPostBuild({ reporter }, pluginOptions) {
   const options = { ...defaultOptions, ...pluginOptions }
   const fileBasePath = path.join(process.cwd(), 'public')
   const patternExt = (options.extensions.length > 1) ? `{${options.extensions.join(',')}}` : options.extensions[0]
   const pattern = `**/*.${patternExt}`
 
   const files = await globAsync(pattern, { cwd: fileBasePath, ignore: '**/*.gz', nodir: true })
-  const tmrStart = new Date().getTime()
 
   const compressFile = workerFarm(worker)
+
+  const activity = reporter.activityTimer('Zopfli compression')
+  activity.start()
+
+  let totalCompressed = 0;
+  let totalSavings = 0;
   const compress = files.map(file => {
     return new Promise((resolve, reject) => {
-      compressFile(file, pluginOptions, err => err ? reject(err) : resolve())
+      compressFile(file, pluginOptions, (details, err) => {
+        if (err) {
+          reporter.panicOnBuild(`Zopfli compression failed ${err}`)
+          reject(err)
+        }
+        if (pluginOptions.verbose) {
+          reporter.verbose(`${file} - original size: ${bytesToSize(details.originalSize)} compressed size: ${bytesToSize(details.compressedSize)}`)
+        }
+        totalSavings += (details.originalSize - details.compressedSize)
+        activity.setStatus(` ${file} ${++totalCompressed}/${files.length}`)
+        resolve()
+      })
     })
   })
   await Promise.all(compress)
   workerFarm.end(compressFile)
 
-  const tmrEnd = new Date().getTime()
-  console.log(`Zopfli compressed ${files.length} files in ${(tmrEnd - tmrStart) / 1000} s`)
+  activity.setStatus(` ${totalCompressed}/${files.length}`)
+  activity.end()
+
+  reporter.info(`Zopfli compression total payload reduced ${bytesToSize(totalSavings)}`)
 }
 
+// courtesy https://web.archive.org/web/20120507054320/http://codeaid.net/javascript/convert-size-in-bytes-to-human-readable-format-(javascript)
+const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+const bytesToSize = (bytes) => {
+  if (bytes < 2) return `${bytes} Byte`;
+  const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
+  return `${Math.round(bytes / Math.pow(1024, i), 2)} ${sizes[i]}`;
+}
+
+
 exports.onPostBuild = onPostBuild
+

--- a/src/zopfli-plugin.js
+++ b/src/zopfli-plugin.js
@@ -26,8 +26,8 @@ async function onPostBuild({ reporter }, pluginOptions) {
   const activity = reporter.activityTimer('Zopfli compression')
   activity.start()
 
-  let totalCompressed = 0;
-  let totalSavings = 0;
+  let totalCompressed = 0
+  let totalSavings = 0
   const compress = files.map(file => {
     return new Promise((resolve, reject) => {
       compressFile(file, pluginOptions, (details, err) => {
@@ -54,13 +54,12 @@ async function onPostBuild({ reporter }, pluginOptions) {
 }
 
 // courtesy https://web.archive.org/web/20120507054320/http://codeaid.net/javascript/convert-size-in-bytes-to-human-readable-format-(javascript)
-const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
 const bytesToSize = (bytes) => {
-  if (bytes < 2) return `${bytes} Byte`;
-  const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
-  return `${Math.round(bytes / Math.pow(1024, i), 2)} ${sizes[i]}`;
+  if (bytes < 2) return `${bytes} Byte`
+  const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)))
+  return `${Math.round(bytes / Math.pow(1024, i), 2)} ${sizes[i]}`
 }
 
 
 exports.onPostBuild = onPostBuild
-


### PR DESCRIPTION
   -  Uses the gatsby reporter in favor of console.log provide feedback while compression is taking place as well as to take advantage of the built-in timing mechanism
   -  Allows the consumer to pass in options to the backing zopfli library for more fine-grained control
   -  Provides verbose feedback as an opt-in feature for users of the library that require more detailed feedback
   -  Updates documentation for the above changes