### PR TITLE
Use GatsbyReporter to provide consistent logging experience and allow passing options to zopfil library

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ module.exports = {
 }
 ```
 
+To customize compression, you can add optional parameters to the zopfli library: ([see here for details on various options)](https://github.com/pierreinglebert/node-zopfli#options)
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-zopfli',
+      zopfli: {
+        verbose: false,
+        verbose_more: false,
+        numiterations: 15,
+        blocksplitting: true,
+        blocksplittinglast: false,
+        blocksplittingmax: 15
+      }
+    }
+  ]
+}
+```
+
+For diagnostic information, you can enable verbose logging:
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-zopfli',
+      verbose: true
+    }
+  ]
+}
+```
+
 ## Maintainers
 
 Osmond van Hemert

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gatsby-plugin-zopfli
 
 [![Travis](https://img.shields.io/travis/com/ovhemert/gatsby-plugin-zopfli.svg?branch=master&logo=travis)](https://travis-ci.com/ovhemert/gatsby-plugin-zopfli)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/6b2619c09ca94862bf349f40eb913466)](https://www.codacy.com/app/ovhemert/gatsby-plugin-zopfli?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ovhemert/gatsby-plugin-zopfli&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/6b2619c09ca94862bf349f40eb913466)](https://www.codacy.com/app/ovhemert/gatsby-plugin-zopfli?utm_source=github.com&utm_medium=referral&utm_content=ovhemert/gatsby-plugin-zopfli&utm_campaign=Badge_Grade)
 [![Known Vulnerabilities](https://snyk.io/test/npm/gatsby-plugin-zopfli/badge.svg)](https://snyk.io/test/npm/gatsby-plugin-zopfli)
 [![Coverage Status](https://coveralls.io/repos/github/ovhemert/gatsby-plugin-zopfli/badge.svg)](https://coveralls.io/github/ovhemert/gatsby-plugin-zopfli)
 [![Greenkeeper badge](https://badges.greenkeeper.io/ovhemert/gatsby-plugin-zopfli.svg)](https://greenkeeper.io/)
@@ -18,7 +18,9 @@ Files compressed with Zopfli can be decompressed with existing methods on the cl
 ```bash
 /webpack-runtime-cde5506958f1afc4d89e.js
 ```
+
 becomes
+
 ```bash
 /webpack-runtime-cde5506958f1afc4d89e.js.gz
 ```
@@ -49,10 +51,10 @@ In your `gatsby-config.js` file add:
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-plugin-zopfli'
+      resolve: "gatsby-plugin-zopfli"
     }
   ]
-}
+};
 ```
 
 By default, only `.css` and `.js` files are compressed, but you can override this with the `extensions` option.
@@ -61,13 +63,13 @@ By default, only `.css` and `.js` files are compressed, but you can override thi
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-plugin-zopfli',
+      resolve: "gatsby-plugin-zopfli",
       options: {
-        extensions: ['css', 'html', 'js', 'svg']
+        extensions: ["css", "html", "js", "svg"]
       }
     }
   ]
-}
+};
 ```
 
 You can even place all the zopfli-compressed files in a dedicated directory (ex. `public/zopfli`):
@@ -76,13 +78,13 @@ You can even place all the zopfli-compressed files in a dedicated directory (ex.
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-plugin-zopfli',
+      resolve: "gatsby-plugin-zopfli",
       options: {
-        path: 'zopfli'
+        path: "zopfli"
       }
     }
   ]
-}
+};
 ```
 
 To customize compression, you can add optional parameters to the zopfli library: ([see here for details on various options)](https://github.com/pierreinglebert/node-zopfli#options)
@@ -91,18 +93,16 @@ To customize compression, you can add optional parameters to the zopfli library:
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-plugin-zopfli',
-      zopfli: {
-        verbose: false,
-        verbose_more: false,
-        numiterations: 15,
-        blocksplitting: true,
-        blocksplittinglast: false,
-        blocksplittingmax: 15
+      resolve: "gatsby-plugin-zopfli",
+      options: {
+        path: "zopfli",
+        compression: {
+          numiterations: 25
+        }
       }
     }
   ]
-}
+};
 ```
 
 For diagnostic information, you can enable verbose logging:
@@ -111,11 +111,13 @@ For diagnostic information, you can enable verbose logging:
 module.exports = {
   plugins: [
     {
-      resolve: 'gatsby-plugin-zopfli',
-      verbose: true
+      resolve: "gatsby-plugin-zopfli",
+      options: {
+        verbose: true
+      }
     }
   ]
-}
+};
 ```
 
 ## Maintainers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-zopfli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Gatsby plugin for preparing zopfli-compressed versions of assets",
   "main": "index.js",
   "scripts": {

--- a/src/worker.js
+++ b/src/worker.js
@@ -28,7 +28,7 @@ async function compressFile (file, pluginOptions = {}) {
     compressedSize: compressed.length
   }
 
-  return result;
+  return result
 }
 
 module.exports = function (file, options, callback) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -9,7 +9,7 @@ const mkdirpAsync = util.promisify(mkdirp)
 const readFileAsync = util.promisify(fs.readFile)
 const writeFileAsync = util.promisify(fs.writeFile)
 
-async function compressFile(file, pluginOptions = {}) {
+async function compressFile (file, pluginOptions = {}) {
   // zopfli-gzip the asset to a new file with the .gz extension
   const fileBasePath = path.join(process.cwd(), 'public')
   const srcFileName = path.join(fileBasePath, file)
@@ -23,10 +23,12 @@ async function compressFile(file, pluginOptions = {}) {
   await mkdirpAsync(destFileDirname)
   await writeFileAsync(destFileName, compressed)
 
-  return {
+  const result = {
     originalSize: content.length,
     compressedSize: compressed.length
-  };
+  }
+
+  return result;
 }
 
 module.exports = function (file, options, callback) {

--- a/src/zopfli-plugin.js
+++ b/src/zopfli-plugin.js
@@ -13,26 +13,52 @@ const defaultOptions = {
 
 const globAsync = util.promisify(glob)
 
-async function onPostBuild (args, pluginOptions) {
+async function onPostBuild ({ reporter }, pluginOptions) {
   const options = { ...defaultOptions, ...pluginOptions }
   const fileBasePath = path.join(process.cwd(), 'public')
   const patternExt = (options.extensions.length > 1) ? `{${options.extensions.join(',')}}` : options.extensions[0]
   const pattern = `**/*.${patternExt}`
 
   const files = await globAsync(pattern, { cwd: fileBasePath, ignore: '**/*.gz', nodir: true })
-  const tmrStart = new Date().getTime()
 
   const compressFile = workerFarm(worker)
+
+  const activity = reporter.activityTimer('Zopfli compression')
+  activity.start()
+
+  let totalCompressed = 0
+  let totalSavings = 0
   const compress = files.map(file => {
     return new Promise((resolve, reject) => {
-      compressFile(file, pluginOptions, err => err ? reject(err) : resolve())
+      compressFile(file, pluginOptions, (details, err) => {
+        if (err) {
+          reporter.panicOnBuild(`Zopfli compression failed ${err}`)
+          reject(err)
+        }
+        if (pluginOptions.verbose) {
+          reporter.verbose(`${file} - original size: ${bytesToSize(details.originalSize)} compressed size: ${bytesToSize(details.compressedSize)}`)
+        }
+        totalSavings += (details.originalSize - details.compressedSize)
+        activity.setStatus(` ${file} ${++totalCompressed}/${files.length}`)
+        resolve()
+      })
     })
   })
   await Promise.all(compress)
   workerFarm.end(compressFile)
 
-  const tmrEnd = new Date().getTime()
-  console.log(`Zopfli compressed ${files.length} files in ${(tmrEnd - tmrStart) / 1000} s`)
+  activity.setStatus(` ${totalCompressed}/${files.length}`)
+  activity.end()
+
+  reporter.info(`Zopfli compression total payload reduced ${bytesToSize(totalSavings)}`)
+}
+
+// courtesy https://web.archive.org/web/20120507054320/http://codeaid.net/javascript/convert-size-in-bytes-to-human-readable-format-(javascript)
+const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+const bytesToSize = (bytes) => {
+  if (bytes < 2) return `${bytes} Byte`
+  const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)))
+  return `${Math.round(bytes / Math.pow(1024, i), 2)} ${sizes[i]}`
 }
 
 exports.onPostBuild = onPostBuild


### PR DESCRIPTION
   -  Uses the gatsby reporter in favor of console.log provide feedback while compression is taking place as well as to take advantage of the built-in timing mechanism
   -  Allows the consumer to pass in options to the backing zopfli library for more fine-grained control
   -  Provides verbose feedback as an opt-in feature for users of the library that require more detailed feedback
   -  Updates documentation for the above changes