### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ module.exports = {
       resolve: 'gatsby-plugin-zopfli',
       options: {
         path: 'zopfli',
-        compression: {
           numiterations: 25
-        }
       }
     }
   ]


### PR DESCRIPTION
numiterations is directly below `options:{}` instead of `options:{ compression:{}}`
